### PR TITLE
Mobile Button Error Fix

### DIFF
--- a/Source.lua
+++ b/Source.lua
@@ -1787,6 +1787,17 @@ local ResizePos = false -- Not Implemented as of Alpha Release 2
 
 local GUICanvasSize = { X = Camera.ViewportSize.X, Y = Camera.ViewportSize.Y - GuiInset }
 
+--// SUBSECTION : Interface Variables
+
+local mainWindow : Frame = StarlightUI.MainWindow
+local Resources = StarlightUI.Resources
+local navigation : Frame = mainWindow.Sidebar.Navigation
+local tabs : Frame = mainWindow.Content.ContentMain.Elements
+local Resizing = false -- Not Implemented as of Alpha Release 2
+local ResizePos = false -- Not Implemented as of Alpha Release 2
+
+local GUICanvasSize = { X = Camera.ViewportSize.X, Y = Camera.ViewportSize.Y - GuiInset }
+
 --// ENDSUBSECTION 
  
 if UserInputService.TouchEnabled and not UserInputService.KeyboardEnabled then


### PR DESCRIPTION
From line 1790
To line 1815

The problem was that some games have mobile jump button disabled as their game mechanics might not require jumping like street life where jumping is disabled (jumpPower set to 0)

Why the old script was catching error?
It was calling jumpButton if the TouchGui existed and yes TouchGui exists however the jumpButton may not exist depending on the game therefore simply adding some extra checks and checking if the jumpButton exists inside TouchGui will fix the issue. 