### PR TITLE
Remove detection

### DIFF
--- a/Source.lua
+++ b/Source.lua
@@ -122,6 +122,11 @@ local MarketplaceService = GetService("MarketplaceService")
 local ReplicatedStorage = GetService("ReplicatedStorage")
 local ContentProvider = GetService("ContentProvider")
 local CoreGui = GetService("CoreGui")
+local InputManager
+
+if not getgenv().SecureMode then
+	InputManager = GetService("VirtualInputManager")
+end
 
 local Player = Players.LocalPlayer
 local PlayerGui = Player:WaitForChild("PlayerGui")
@@ -1522,7 +1527,27 @@ local function Hide(Interface, JustHide: boolean?, Notify: boolean?, Bind: strin
 		end
 	end
 
-
+	-- hide popups
+	if InputManager then
+		if not isStudio and Starlight.Instance.MobileToggle.Visible then
+			InputManager:SendTouchEvent(
+				0, 0, 0, 0
+			)
+	
+			InputManager:SendTouchEvent(
+				0, 2, 0, 0
+			)
+		elseif not isStudio then
+			InputManager:SendMouseButtonEvent(
+				0, 0, 0, true, game, 0
+			)
+	
+			InputManager:SendMouseButtonEvent(
+				0, 0, 0, false, game, 0
+			)
+		end
+	end
+	
 	task.wait(0.18)
 	if Interface.ClassName == "ScreenGui" then
 		Interface.Enabled = false

--- a/Source.lua
+++ b/Source.lua
@@ -121,7 +121,6 @@ local GuiService = GetService("GuiService")
 local MarketplaceService = GetService("MarketplaceService")
 local ReplicatedStorage = GetService("ReplicatedStorage")
 local ContentProvider = GetService("ContentProvider")
-local InputManager = GetService("VirtualInputManager")
 local CoreGui = GetService("CoreGui")
 
 local Player = Players.LocalPlayer
@@ -1521,25 +1520,6 @@ local function Hide(Interface, JustHide: boolean?, Notify: boolean?, Bind: strin
 		if Interface.ClassName == "UIStroke" or Interface.ClassName == "UIGradient" then
 			Tween(Interface, { Transparency = 1 })
 		end
-	end
-	
-	-- hide popups
-	if not isStudio and Starlight.Instance.MobileToggle.Visible then
-		InputManager:SendTouchEvent(
-			0, 0, 0, 0
-		)
-
-		InputManager:SendTouchEvent(
-			0, 2, 0, 0
-		)
-	elseif not isStudio then
-		InputManager:SendMouseButtonEvent(
-			0, 0, 0, true, game, 0
-		)
-
-		InputManager:SendMouseButtonEvent(
-			0, 0, 0, false, game, 0
-		)
 	end
 
 


### PR DESCRIPTION
remove easily detectable service
many anticheats and games check for VirtualInputManager

getgenv().SecureMode = true
loadstring(game:HttpGet("https://raw.nebulasoftworks.xyz/starlight"))()

Only doing this, not even loading up the UI and you are already detectable and its being used for some dumb thing.

if game:FindService("VirtualInputManager") then
    -- Detected
end